### PR TITLE
Test `pull_request_target` workflow trigger

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add to project
+    name: This message shouldnt be seen in the workflow i think
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           project-url: "https://github.com/orgs/R2Northstar/projects/3"
           github-token: "${{ secrets.ADD_TO_PROJECT_PAT }}"
+


### PR DESCRIPTION
Hopefully the workflow that is ran should have the name "Add to project" and not "This message shouldnt be seen in the workflow i think", which would prove that modifications to the yml don't get used. In turn, this should make it safe to use `pull_request_target` on the actual mods repo, and therefore automate adding PRs to the project